### PR TITLE
No auth

### DIFF
--- a/smtpurl.go
+++ b/smtpurl.go
@@ -34,6 +34,9 @@ func Parse(raw string) (string, smtp.Auth, error) {
 		return "", nil, fmt.Errorf("invalid url: %s", raw)
 	}
 	host := fmt.Sprintf("%s:%s", hostname, port)
+	if u.User == nil {
+		return host, nil, nil
+	}
 	var auth smtp.Auth
 	if strings.Contains(strings.ToUpper(u.User.Username()), authToken) {
 		// ref: https://datatracker.ietf.org/doc/html/draft-earhart-url-smtp-00

--- a/smtpurl_test.go
+++ b/smtpurl_test.go
@@ -43,6 +43,12 @@ func TestParse(t *testing.T) {
 			smtp.CRAMMD5Auth("username", "password"),
 			false,
 		},
+		{
+			"smtp://smtp.example.com",
+			"smtp.example.com:25",
+			nil,
+			false,
+		},
 	}
 	for _, tt := range tests {
 		gotServer, gotAuth, err := Parse(tt.raw)


### PR DESCRIPTION
実装のイメージです

RFCの以下の部分に準拠する必要がある

- https://datatracker.ietf.org/doc/html/draft-earhart-url-smtp-00#section-3
- https://datatracker.ietf.org/doc/html/draft-earhart-url-smtp-00#section-4

>    A user name and/or authentication mechanism may be supplied.  They are used to perform SASL [SASL] authentication after making the connection to the SMTP server.  If no user name or authentication mechanism is supplied, then the SASL ANONYMOUS [SASL-ANON] mechanism is used by default.

section3に上記のように書かれており、このプルリクエストの実装のようにnilを返すことがRFCに反することにならないかを確認する必要がある